### PR TITLE
Add FuturMix AI platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ words with AI, powered by DALL·E.
 - [Visual Studio IntelliCode](https://visualstudio.microsoft.com/services/intellicode/) - IntelliCode helps you drive accuracy and consistency with code completion that can fill in a whole line at once, supporting VS Code and VS IDE.
 - [Embedchain](https://github.com/embedchain/embedchain) - Framework to create ChatGPT like bots over your dataset.
 - [GPTRouter](https://gpt-router.writesonic.com/) - GPTRouter is an open source LLM API Gateway that offers a universal API for 30+ LLMs, vision, and image models, with smart fallbacks based on uptime and latency, automatic retries, and streaming. Stay operational even when OpenAI is down.
+- [FuturMix](https://futurmix.ai/) - Unified AI gateway providing OpenAI-compatible access to 22+ models (GPT-4o, Claude, Gemini) through a single API endpoint and key. 10-20% cheaper than official pricing, 99.99% SLA with automatic failover.
 
 ## Applications and Demos
 


### PR DESCRIPTION
Adds [FuturMix](https://futurmix.ai) next to the existing GPTRouter entry.

FuturMix is an enterprise AI agent platform providing OpenAI-compatible access to 22+ models (GPT-4o, Claude, Gemini) . Features competitive enterprise pricing, 99.99% SLA with automatic failover.